### PR TITLE
Adjust carousel spacing and centering

### DIFF
--- a/CafeElMejor/frontend/styles.css
+++ b/CafeElMejor/frontend/styles.css
@@ -107,7 +107,7 @@ h1.titulo-principal {
   width: 200%;
   display: flex;
   flex-flow: row nowrap;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   margin-top: -2em;
   color: var(--text-color);
@@ -117,9 +117,11 @@ h1.titulo-principal {
   transform: translateX(0%);
 }
 .carrousel .img {
+  box-sizing: border-box;
   width: 50%;
+  padding: 0 10px;
   height: 300px;
-  object-fit: cover;
+  object-fit: contain;
   display: block;
   margin: 0 auto;
   color: var(--text-color);


### PR DESCRIPTION
## Summary
- adjust flex alignment in carousel container
- add padding and box sizing to carousel images for spacing
- use `object-fit: contain` for centered images

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ecad7c348832c8035424a86b55afa