### PR TITLE
Fix carousel second slide visibility

### DIFF
--- a/CafeElMejor/frontend/landing.js
+++ b/CafeElMejor/frontend/landing.js
@@ -9,7 +9,7 @@ punto.forEach( ( cadaPunto , i )=> {
         // Guardar la posición de ese PUNTO
         let posicion  = i
         // Calculando el espacio que debe DESPLAZARSE el GRANDE
-        let operacion = posicion * -100
+        let operacion = posicion * -50
 
         // MOVEMOS el grande
         grande.style.transform = `translateX(${ operacion }%)`

--- a/CafeElMejor/frontend/styles.css
+++ b/CafeElMejor/frontend/styles.css
@@ -118,7 +118,7 @@ h1.titulo-principal {
 }
 .carrousel .img {
   box-sizing: border-box;
-  width: 100%;
+  width: 50%;
   padding: 0 10px;
   height: 300px;
   object-fit: contain;


### PR DESCRIPTION
## Summary
- adjust carousel slide width so each image only occupies half of the container
- update slide translation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ed0e2372c832cbc0f57e87996d36d