### PR TITLE
Update admin layout with logo header

### DIFF
--- a/CafeElMejor/frontend/admin/dashboard.html
+++ b/CafeElMejor/frontend/admin/dashboard.html
@@ -6,16 +6,19 @@
   <link rel="stylesheet" href="../styles.css">
 </head>
 <body onload="initAdmin()">
+  <header>
+    <img src="../assets/Logo.jpg" class="logo-header" alt="Logo">
+    <button onclick="logout()" class="logout-btn">Cerrar Sesión</button>
+  </header>
+  <nav class="admin-nav">
+    <button onclick="showModule('products')">Productos</button>
+    <button onclick="showModule('users')">Clientes</button>
+    <button onclick="showModule('cobranzas')">Cobranzas</button>
+    <button onclick="showModule('invoices')">Facturas</button>
+    <button onclick="showModule('suppliers')">Proveedores</button>
+    <button onclick="showModule('purchases')">Órdenes de Compra</button>
+  </nav>
   <div class="dashboard-container">
-      <div class="sidebar">
-        <button onclick="showModule('products')">Productos</button>
-        <button onclick="showModule('users')">Clientes</button>
-        <button onclick="showModule('cobranzas')">Cobranzas</button>
-        <button onclick="showModule('invoices')">Facturas</button>
-        <button onclick="showModule('suppliers')">Proveedores</button>
-        <button onclick="showModule('purchases')">Órdenes de Compra</button>
-        <button onclick="logout()" class="logout-btn side">Cerrar Sesión</button>
-      </div>
     <div class="main-content">
       <h2>Panel de Administración</h2>
 

--- a/CafeElMejor/frontend/styles.css
+++ b/CafeElMejor/frontend/styles.css
@@ -229,8 +229,7 @@ main {
 
 /* Admin Dashboard */
 .dashboard-container {
-  display: flex;
-  min-height: 100vh;
+  padding: 20px;
 }
 .sidebar {
   background: var(--bg-light);
@@ -252,6 +251,16 @@ main {
 .main-content {
   flex: 1;
   padding: 20px;
+}
+.admin-nav {
+  display: flex;
+  gap: 10px;
+  background: var(--bg-light);
+  padding: 10px 20px;
+  border-bottom: 4px solid var(--accent-cyan);
+}
+.admin-nav button {
+  margin: 0;
 }
 .module input {
   width: 90%;


### PR DESCRIPTION
## Summary
- switch admin dashboard from sidebar to top navigation
- include brand logo with logout button
- add CSS for new layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ffc0f1938832ca9219990b947046c