### PR TITLE
Adjust admin nav button sizes

### DIFF
--- a/CafeElMejor/frontend/styles.css
+++ b/CafeElMejor/frontend/styles.css
@@ -9,6 +9,11 @@
   --text-color: #ffffff;
 }
 
+/* Ensure padding and borders don't create scrollbars */
+* {
+  box-sizing: border-box;
+}
+
 body {
   font-family: 'Press Start 2P', sans-serif;
   margin: 0;
@@ -260,15 +265,16 @@ main {
 }
 .admin-nav {
   display: flex;
-  gap: 10px;
+  gap: 20px;
   background: var(--bg-light);
-  padding: 10px 20px;
+  padding: 10px;
   border-bottom: 4px solid var(--accent-cyan);
   width: 100%;
 }
 .admin-nav button {
   margin: 0;
   flex: 1;
+  padding: 6px 10px;
 }
 .module input {
   width: 90%;


### PR DESCRIPTION
## Summary
- avoid horizontal scrollbars by applying `box-sizing: border-box` globally
- shrink admin navigation buttons and add more spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687005bf3df0832cb64e900d82fa82ce